### PR TITLE
fix: hardcoded current year in index.html

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -338,7 +338,7 @@
           <div class="row">
             <div class="col s12">
               <div class="left">
-                <p class="footer-text">&copy; 2019 <a href="https://github.com/MTrajK/FootballPoll/"
+                <p class="footer-text">&copy; {{ fullYear }} <a href="https://github.com/MTrajK/FootballPoll/"
                     target="_blank">FootballPoll</a></p>
               </div>
               <div class="right">

--- a/src/site/js/vue-app.js
+++ b/src/site/js/vue-app.js
@@ -54,6 +54,7 @@ new Vue({
             selectedPollIdx: undefined,
             polls: [ /* { info: {}, participants: [] } */],
         },
+        fullYear: new Date().getFullYear(),
     },
     mounted: function () {
         /**


### PR DESCRIPTION
## OVERVIEW

_Remove hardcoded year in index.html._

## WHERE SHOULD THE REVIEWER START?

_`/src/site/index.html`_
_`/src/site/vue-app.js`_

## ANY NEW DEPENDENCIES ADDED?

_None._

- [x] Does it work in IE >= 11?
- [x] _Does it work in other browsers?_

## SCREENSHOTS (if applicable)

![Screen Shot 2020-05-28 at 10 08 45](https://user-images.githubusercontent.com/16154503/83115999-7762f280-a0cb-11ea-8a70-1b9ed81b84f6.png)

## CHECKLIST

- [x] Verify this branch is rebased with the latest master